### PR TITLE
Django < 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django < 4
 djangorestframework
 django-reversion > 3.0.7
 dj-database-url


### PR DESCRIPTION
It is a fast fix of the following exception happening in Django >= 4:
```
cannot import name 'url' from 'django.conf.urls'
```