### PR TITLE
Drop deprecated django.conf.urls.url

### DIFF
--- a/akb/urls.py
+++ b/akb/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from akb import views
 
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
@@ -23,6 +23,6 @@ router.register(r'tags', views.TagViewSet)
 router.register(r'objects', views.ObjectViewSet)
 
 urlpatterns = [
-	url(r'^', include(router.urls)),
-	url(r'^whoami/$', views.whoami, name="whoami"),
+	re_path(r'^', include(router.urls)),
+	re_path(r'^whoami/$', views.whoami, name="whoami"),
 ]


### PR DESCRIPTION
Fix #18
Fix #21